### PR TITLE
Step14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2' // or jjwt-gson if you prefer Gson
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
+    //redis and cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/practice/hhplusecommerce/common/config/RedisConfig.java
+++ b/src/main/java/practice/hhplusecommerce/common/config/RedisConfig.java
@@ -45,9 +45,12 @@ public class RedisConfig {
         .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
         .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
 
+    Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+    cacheConfigurations.put("getTop5ProductsLast3Days", cacheConfig.entryTtl(Duration.ofHours(3)));
 
     return RedisCacheManager.builder(redisConnectionFactory)
         .cacheDefaults(cacheConfig)
+        .withInitialCacheConfigurations(cacheConfigurations)
         .build();
   }
 }

--- a/src/main/java/practice/hhplusecommerce/common/config/RedisConfig.java
+++ b/src/main/java/practice/hhplusecommerce/common/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package practice.hhplusecommerce.common.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
@@ -31,7 +32,12 @@ public class RedisConfig {
 
     ObjectMapper objectMapper = new ObjectMapper()
         .registerModule(new JavaTimeModule())
-        .activateDefaultTyping(polymorphicTypeValidator, DefaultTyping.NON_FINAL);
+        .activateDefaultTyping(polymorphicTypeValidator, DefaultTyping.NON_FINAL)
+        .activateDefaultTyping(
+            BasicPolymorphicTypeValidator.builder().allowIfBaseType(Object.class).build(),
+            ObjectMapper.DefaultTyping.EVERYTHING,
+            JsonTypeInfo.As.PROPERTY
+        );
 
     GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 

--- a/src/main/java/practice/hhplusecommerce/common/test/DatabaseCleanUp.java
+++ b/src/main/java/practice/hhplusecommerce/common/test/DatabaseCleanUp.java
@@ -1,0 +1,68 @@
+package practice.hhplusecommerce.common.test;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Profile("test")
+@Component
+public class DatabaseCleanUp implements InitializingBean {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  private final List<String> tables = new ArrayList<>();
+
+  public DatabaseCleanUp(EntityManager entityManager) {
+    this.entityManager = entityManager;
+  }
+
+  @Override
+  public void afterPropertiesSet() {
+    tables.addAll(entityManager.getMetamodel().getEntities().stream()
+        .filter(entityType -> entityType.getJavaType().isAnnotationPresent(Entity.class))
+        .map(entityType -> {
+          Table table = entityType.getJavaType().getAnnotation(Table.class);
+          if (table != null && !table.name().isEmpty()) {
+            return table.name();
+          } else {
+            return entityType.getName();
+          }
+        })
+        .collect(Collectors.toList()));
+  }
+
+  @Transactional
+  public void execute() {
+    entityManager.flush();
+    entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+    for (String table : tables) {
+
+      entityManager.createNativeQuery("TRUNCATE TABLE " + toSnakeCase(table).toLowerCase()).executeUpdate();
+      entityManager.createNativeQuery("ALTER TABLE " + toSnakeCase(table).toLowerCase() + " AUTO_INCREMENT = 1").executeUpdate();
+    }
+    entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+  }
+
+  private String toSnakeCase(String str) {
+    StringBuilder result = new StringBuilder();
+    result.append(Character.toLowerCase(str.charAt(0)));
+    for (int i = 1; i < str.length(); i++) {
+      char c = str.charAt(i);
+      if (Character.isUpperCase(c)) {
+        result.append('_').append(Character.toLowerCase(c));
+      } else {
+        result.append(c);
+      }
+    }
+    return result.toString();
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/order/business/command/OrderCommand.java
+++ b/src/main/java/practice/hhplusecommerce/order/business/command/OrderCommand.java
@@ -1,0 +1,33 @@
+package practice.hhplusecommerce.order.business.command;
+
+import jakarta.persistence.Tuple;
+
+public class OrderCommand {
+
+  public record Top5ProductsLast3DaysResponse(
+      Long productId,
+      String productName,
+      Integer productPrice,
+      Integer productStock,
+      Long sumQuantity
+  ) {
+
+    public Top5ProductsLast3DaysResponse(Long productId, String productName, Integer productPrice, Integer productStock, Long sumQuantity) {
+      this.productId = productId;
+      this.productName = productName;
+      this.productPrice = productPrice;
+      this.productStock = productStock;
+      this.sumQuantity = sumQuantity;
+    }
+
+    public Top5ProductsLast3DaysResponse(Tuple tuple) {
+      this(
+          (Long) tuple.get("productId"),
+          (String) tuple.get("productName"),
+          (Integer) tuple.get("productPrice"),
+          (Integer) tuple.get("productStock"),
+          (Long) tuple.get("sumQuantity")
+      );
+    }
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/order/business/service/OrderService.java
+++ b/src/main/java/practice/hhplusecommerce/order/business/service/OrderService.java
@@ -4,9 +4,11 @@ import jakarta.persistence.Tuple;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import practice.hhplusecommerce.order.application.dto.request.OrderFacadeRequestDto.OrderProductCreate;
+import practice.hhplusecommerce.order.business.command.OrderCommand;
 import practice.hhplusecommerce.order.business.entity.Order;
 import practice.hhplusecommerce.order.business.entity.OrderProduct;
 import practice.hhplusecommerce.order.business.repository.OrderProductRepository;
@@ -49,9 +51,11 @@ public class OrderService {
   }
 
   @Transactional
-  public List<Tuple> getTop5ProductsLast3Days() {
+  @Cacheable(value = "getTop5ProductsLast3Days")
+  public List<OrderCommand.Top5ProductsLast3DaysResponse> getTop5ProductsLast3Days() {
     LocalDateTime now = LocalDateTime.now();
     LocalDateTime minusDays3 = now.minusDays(3);
-    return orderProductRepository.getTop5ProductsLast3Days(now, minusDays3);
+    List<Tuple> top5ProductsLast3Days = orderProductRepository.getTop5ProductsLast3Days(now, minusDays3);
+    return top5ProductsLast3Days.stream().map(OrderCommand.Top5ProductsLast3DaysResponse::new).toList();
   }
 }

--- a/src/main/java/practice/hhplusecommerce/product/application/ProductFacade.java
+++ b/src/main/java/practice/hhplusecommerce/product/application/ProductFacade.java
@@ -3,13 +3,14 @@ package practice.hhplusecommerce.product.application;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import practice.hhplusecommerce.order.business.service.OrderService;
 import practice.hhplusecommerce.product.application.dto.response.ProductFacadeResponseDto.Response;
 import practice.hhplusecommerce.product.application.dto.response.ProductFacadeResponseDto.Top5ProductsLast3DaysResponse;
 import practice.hhplusecommerce.product.application.dto.response.ProductFacadeResponseDtoMapper;
+import practice.hhplusecommerce.product.business.dto.ProductCommand;
 import practice.hhplusecommerce.product.business.entity.Product;
 import practice.hhplusecommerce.product.business.service.ProductService;
+import practice.hhplusecommerce.product.presentation.request.ProductRequestDto.Update;
 
 @Component
 @RequiredArgsConstructor
@@ -32,5 +33,13 @@ public class ProductFacade {
 
   public List<Top5ProductsLast3DaysResponse> getTop5ProductsLast3Days() {
     return orderService.getTop5ProductsLast3Days().stream().map(ProductFacadeResponseDtoMapper::toTop5ProductsLast3DaysResponse).toList();
+  }
+
+  public void updateProduct(Long productId, Update update) {
+    productService.updateProduct(new ProductCommand.Update(productId, update.name(), update.price(), update.stock()));
+  }
+
+  public void deleteProduct(Long productId) {
+    productService.deleteProduct(productId);
   }
 }

--- a/src/main/java/practice/hhplusecommerce/product/application/dto/response/ProductFacadeResponseDtoMapper.java
+++ b/src/main/java/practice/hhplusecommerce/product/application/dto/response/ProductFacadeResponseDtoMapper.java
@@ -1,22 +1,22 @@
 package practice.hhplusecommerce.product.application.dto.response;
 
-import jakarta.persistence.Tuple;
+import practice.hhplusecommerce.order.business.command.OrderCommand;
 import practice.hhplusecommerce.product.application.dto.response.ProductFacadeResponseDto.Top5ProductsLast3DaysResponse;
 import practice.hhplusecommerce.product.business.entity.Product;
 
 public class ProductFacadeResponseDtoMapper {
 
   public static ProductFacadeResponseDto.Response toProductFacadeDto(Product product) {
-      return new ProductFacadeResponseDto.Response(product.getId(), product.getName(), product.getPrice(), product.getStock());
+    return new ProductFacadeResponseDto.Response(product.getId(), product.getName(), product.getPrice(), product.getStock());
   }
 
-  public static ProductFacadeResponseDto.Top5ProductsLast3DaysResponse toTop5ProductsLast3DaysResponse(Tuple tuple) {
+  public static ProductFacadeResponseDto.Top5ProductsLast3DaysResponse toTop5ProductsLast3DaysResponse(OrderCommand.Top5ProductsLast3DaysResponse command) {
     ProductFacadeResponseDto.Top5ProductsLast3DaysResponse top5ProductsLast3DaysResponse = new Top5ProductsLast3DaysResponse();
-    top5ProductsLast3DaysResponse.setProductId((Long) tuple.get("productId"));
-    top5ProductsLast3DaysResponse.setProductName((String) tuple.get("productName"));
-    top5ProductsLast3DaysResponse.setProductStock((Integer) tuple.get("productStock"));
-    top5ProductsLast3DaysResponse.setProductPrice((Integer) tuple.get("productPrice"));
-    top5ProductsLast3DaysResponse.setSumQuantity((Long) tuple.get("sumQuantity"));
+    top5ProductsLast3DaysResponse.setProductId(command.productId());
+    top5ProductsLast3DaysResponse.setProductName(command.productName());
+    top5ProductsLast3DaysResponse.setProductStock(command.productStock());
+    top5ProductsLast3DaysResponse.setProductPrice(command.productPrice());
+    top5ProductsLast3DaysResponse.setSumQuantity(command.sumQuantity());
     return top5ProductsLast3DaysResponse;
   }
 }

--- a/src/main/java/practice/hhplusecommerce/product/business/dto/ProductCommand.java
+++ b/src/main/java/practice/hhplusecommerce/product/business/dto/ProductCommand.java
@@ -1,0 +1,19 @@
+package practice.hhplusecommerce.product.business.dto;
+
+public class ProductCommand {
+
+  public record Update(
+      Long id,
+      String name,
+      Integer price,
+      Integer stock
+  ) {
+
+    public Update(Long id, String name, Integer price, Integer stock) {
+      this.id = id;
+      this.name = name;
+      this.price = price;
+      this.stock = stock;
+    }
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/product/business/entity/Product.java
+++ b/src/main/java/practice/hhplusecommerce/product/business/entity/Product.java
@@ -52,4 +52,16 @@ public class Product extends BaseLocalDateTimeEntity {
       throw new BadRequestException("재고가 부족합니다.");
     }
   }
+
+  public void update(String name, Integer stock, Integer price) {
+    if (stock < 0) {
+      throw new BadRequestException("재고가 0보다 작을 수 없습니다.");
+    } else if (price < 0) {
+      throw new BadRequestException("가격이 0보다 작을 수 없습니다.");
+    }
+
+    this.stock = stock;
+    this.name = name;
+    this.price = price;
+  }
 }

--- a/src/main/java/practice/hhplusecommerce/product/business/repository/ProductRepository.java
+++ b/src/main/java/practice/hhplusecommerce/product/business/repository/ProductRepository.java
@@ -19,4 +19,6 @@ public interface ProductRepository {
   List<Product> getProductListByProductIdListPessimisticRock(List<Long> productIdList);
 
   void deleteAllInBatch(List<Product> productList);
+
+  void deleteById(Long productId);
 }

--- a/src/main/java/practice/hhplusecommerce/product/business/service/ProductService.java
+++ b/src/main/java/practice/hhplusecommerce/product/business/service/ProductService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import practice.hhplusecommerce.common.exception.NotFoundException;
@@ -18,6 +19,7 @@ public class ProductService {
   private final ProductRepository productRepository;
 
   @Transactional
+  @Cacheable(value = "getProductList")
   public List<Product> getProductList() {
     return productRepository.findAll();
   }

--- a/src/main/java/practice/hhplusecommerce/product/business/service/ProductService.java
+++ b/src/main/java/practice/hhplusecommerce/product/business/service/ProductService.java
@@ -4,10 +4,12 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import practice.hhplusecommerce.common.exception.NotFoundException;
+import practice.hhplusecommerce.product.business.dto.ProductCommand;
 import practice.hhplusecommerce.product.business.entity.Product;
 import practice.hhplusecommerce.product.business.repository.ProductRepository;
 
@@ -19,9 +21,23 @@ public class ProductService {
   private final ProductRepository productRepository;
 
   @Transactional
-  @Cacheable(value = "getProductList")
+  @Cacheable(value = "getProductList", key = "0")
   public List<Product> getProductList() {
     return productRepository.findAll();
+  }
+
+  @Transactional
+  @CacheEvict(value = "getProductList", key = "0")
+  public void deleteProduct(Long productId) {
+    productRepository.deleteById(productId);
+  }
+
+  @Transactional
+  @CacheEvict(value = "getProductList", key = "0")
+  public Product updateProduct(ProductCommand.Update command) {
+    Product product = productRepository.findById(command.id()).orElseThrow(() -> new NotFoundException("상품", true));
+    product.update(command.name(), command.stock(), command.price());
+    return product;
   }
 
   @Transactional

--- a/src/main/java/practice/hhplusecommerce/product/infrastructure/repository/ProductRepositoryImpl.java
+++ b/src/main/java/practice/hhplusecommerce/product/infrastructure/repository/ProductRepositoryImpl.java
@@ -47,4 +47,9 @@ public class ProductRepositoryImpl implements ProductRepository {
   public void deleteAllInBatch(List<Product> productList) {
     productJpaRepository.deleteAllInBatch(productList);
   }
+
+  @Override
+  public void deleteById(Long productId) {
+    productJpaRepository.deleteById(productId);
+  }
 }

--- a/src/main/java/practice/hhplusecommerce/product/presentation/ProductController.java
+++ b/src/main/java/practice/hhplusecommerce/product/presentation/ProductController.java
@@ -4,11 +4,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import practice.hhplusecommerce.product.application.ProductFacade;
+import practice.hhplusecommerce.product.presentation.request.ProductRequestDto;
 import practice.hhplusecommerce.product.presentation.response.ProductResponseDto.ProductResponse;
 import practice.hhplusecommerce.product.presentation.response.ProductResponseDtoMapper;
 
@@ -43,5 +48,20 @@ public class ProductController {
         .stream()
         .map(ProductResponseDtoMapper::toProductResponse)
         .toList();
+  }
+
+  @Operation(summary = "상품 수정")
+  @PutMapping("/{product-id}")
+  public void updateProduct(
+      @PathVariable("product-id") Long productId,
+      @RequestBody @Validated ProductRequestDto.Update update
+  ) {
+    productFacade.updateProduct(productId, update);
+  }
+
+  @Operation(summary = "상품 삭제")
+  @DeleteMapping("/{product-id}")
+  public void deleteProduct(@PathVariable("product-id") Long productId) {
+    productFacade.deleteProduct(productId);
   }
 }

--- a/src/main/java/practice/hhplusecommerce/product/presentation/request/ProductRequestDto.java
+++ b/src/main/java/practice/hhplusecommerce/product/presentation/request/ProductRequestDto.java
@@ -1,0 +1,30 @@
+package practice.hhplusecommerce.product.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class ProductRequestDto {
+
+  public record Update(
+
+      @NotBlank(message = "금액이 필요합니다.")
+      @Schema(description = "상품명", defaultValue = "탁자")
+      String name,
+
+      @NotNull(message = "금액이 필요합니다.")
+      @Schema(description = "금액", defaultValue = "1500")
+      Integer price,
+
+      @NotNull(message = "재고가 필요합니다.")
+      @Schema(description = "재고", defaultValue = "5")
+      Integer stock
+  ) {
+
+    public Update(String name, Integer price, Integer stock) {
+      this.name = name;
+      this.price = price;
+      this.stock = stock;
+    }
+  }
+}

--- a/src/test/java/practice/hhplusecommerce/order/business/OrderServiceCacheIntegrationTest.java
+++ b/src/test/java/practice/hhplusecommerce/order/business/OrderServiceCacheIntegrationTest.java
@@ -1,0 +1,124 @@
+package practice.hhplusecommerce.order.business;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.ActiveProfiles;
+import practice.hhplusecommerce.common.test.DatabaseCleanUp;
+import practice.hhplusecommerce.order.business.command.OrderCommand.Top5ProductsLast3DaysResponse;
+import practice.hhplusecommerce.order.business.entity.Order;
+import practice.hhplusecommerce.order.business.entity.OrderProduct;
+import practice.hhplusecommerce.order.business.repository.OrderProductRepository;
+import practice.hhplusecommerce.order.business.repository.OrderRepository;
+import practice.hhplusecommerce.order.business.service.OrderService;
+import practice.hhplusecommerce.product.business.entity.Product;
+import practice.hhplusecommerce.product.business.repository.ProductRepository;
+import practice.hhplusecommerce.user.business.entity.User;
+import practice.hhplusecommerce.user.business.repository.UserRepository;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class OrderServiceCacheIntegrationTest {
+
+  @SpyBean
+  OrderService orderService;
+
+  @Autowired
+  OrderRepository orderRepository;
+
+  @SpyBean
+  OrderProductRepository orderProductRepository;
+
+  @Autowired
+  ProductRepository productRepository;
+
+  @Autowired
+  UserRepository userRepository;
+
+  @Autowired
+  DatabaseCleanUp databaseCleanUp;
+
+  @Autowired
+  CacheManager cacheManager;
+
+  @BeforeAll
+  public void setUpBefore() {
+    List<Product> productList = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      productList.add(new Product(null, "꽃병" + i, 1500, 20));
+    }
+
+    List<Product> saveProductList = new ArrayList<>();
+    for (Product product : productList) {
+      saveProductList.add(productRepository.save(product));
+    }
+
+    User user = new User(null, "백현명", 0);
+    User saveUser = userRepository.save(user);
+
+    Order order = new Order(null, 1500, saveUser);
+    Order saveOrder = orderRepository.save(order);
+
+    //랜덤으로 주문상품 저장
+    Random random = new Random();
+    for (int i = 0; i < 100; i++) {
+      int j = random.nextInt(10);
+      orderProductRepository.save(
+          new OrderProduct(
+              null,
+              saveProductList.get(j).getName(),
+              saveProductList.get(j).getPrice(),
+              3,
+              saveOrder,
+              saveProductList.get(j)
+          )
+      );
+    }
+  }
+
+  @AfterAll
+  public void tearDownAfter() {
+    databaseCleanUp.execute();
+  }
+
+  @Test
+  @DisplayName("인기상품조회 두번째 조회부터 캐싱 되는지 체크")
+  public void getTop5ProductsLast3Days_cache_success() {
+    //given
+    cacheManager.getCache("getTop5ProductsLast3Days").clear();
+
+    //when
+    List<Top5ProductsLast3DaysResponse> top5ProductsLast3Days = orderService.getTop5ProductsLast3Days();
+    List<Top5ProductsLast3DaysResponse> cacheTop5ProductsLast3Days = orderService.getTop5ProductsLast3Days();
+    orderService.getTop5ProductsLast3Days();
+
+    //then
+    verify(orderProductRepository, times(1)).getTop5ProductsLast3Days(any(LocalDateTime.class), any(LocalDateTime.class));
+    assertEquals(top5ProductsLast3Days.get(0).productId(), cacheTop5ProductsLast3Days.get(0).productId());
+    assertEquals(top5ProductsLast3Days.get(0).productName(), cacheTop5ProductsLast3Days.get(0).productName());
+    assertEquals(top5ProductsLast3Days.get(1).productId(), cacheTop5ProductsLast3Days.get(1).productId());
+    assertEquals(top5ProductsLast3Days.get(1).productName(), cacheTop5ProductsLast3Days.get(1).productName());
+    assertEquals(top5ProductsLast3Days.get(2).productId(), cacheTop5ProductsLast3Days.get(2).productId());
+    assertEquals(top5ProductsLast3Days.get(2).productName(), cacheTop5ProductsLast3Days.get(2).productName());
+    assertEquals(top5ProductsLast3Days.get(3).productId(), cacheTop5ProductsLast3Days.get(3).productId());
+    assertEquals(top5ProductsLast3Days.get(3).productName(), cacheTop5ProductsLast3Days.get(3).productName());
+    assertEquals(top5ProductsLast3Days.get(4).productId(), cacheTop5ProductsLast3Days.get(4).productId());
+    assertEquals(top5ProductsLast3Days.get(4).productName(), cacheTop5ProductsLast3Days.get(4).productName());
+  }
+}

--- a/src/test/java/practice/hhplusecommerce/order/business/OrderServiceIntegrationTest.java
+++ b/src/test/java/practice/hhplusecommerce/order/business/OrderServiceIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import practice.hhplusecommerce.order.application.dto.request.OrderFacadeRequestDto;
 import practice.hhplusecommerce.order.application.dto.request.OrderFacadeRequestDto.Create;
 import practice.hhplusecommerce.order.application.dto.request.OrderFacadeRequestDto.OrderProductCreate;
+import practice.hhplusecommerce.order.business.command.OrderCommand.Top5ProductsLast3DaysResponse;
 import practice.hhplusecommerce.order.business.entity.Order;
 import practice.hhplusecommerce.order.business.entity.OrderProduct;
 import practice.hhplusecommerce.order.business.repository.OrderProductRepository;
@@ -109,20 +110,20 @@ public class OrderServiceIntegrationTest {
         .toList();
 
     //when
-    List<Tuple> top5ProductsLast3Days = orderService.getTop5ProductsLast3Days();
+    List<Top5ProductsLast3DaysResponse> top5ProductsLast3Days = orderService.getTop5ProductsLast3Days();
 
     //then
     //순위가맞고 상품고유번호가 맞는지 체크
-    assertEquals(sortedEntries.get(0).getKey(), top5ProductsLast3Days.get(0).get("productId"));
-    assertEquals(Long.valueOf(sortedEntries.get(0).getValue()), top5ProductsLast3Days.get(0).get("sumQuantity"));
-    assertEquals(sortedEntries.get(1).getKey(), top5ProductsLast3Days.get(1).get("productId"));
-    assertEquals(Long.valueOf(sortedEntries.get(1).getValue()), top5ProductsLast3Days.get(1).get("sumQuantity"));
-    assertEquals(sortedEntries.get(2).getKey(), top5ProductsLast3Days.get(2).get("productId"));
-    assertEquals(Long.valueOf(sortedEntries.get(2).getValue()), top5ProductsLast3Days.get(2).get("sumQuantity"));
-    assertEquals(sortedEntries.get(3).getKey(), top5ProductsLast3Days.get(3).get("productId"));
-    assertEquals(Long.valueOf(sortedEntries.get(3).getValue()), top5ProductsLast3Days.get(3).get("sumQuantity"));
-    assertEquals(sortedEntries.get(4).getKey(), top5ProductsLast3Days.get(4).get("productId"));
-    assertEquals(Long.valueOf(sortedEntries.get(4).getValue()), top5ProductsLast3Days.get(4).get("sumQuantity"));
+    assertEquals(sortedEntries.get(0).getKey(), top5ProductsLast3Days.get(0).productId());
+    assertEquals(Long.valueOf(sortedEntries.get(0).getValue()), top5ProductsLast3Days.get(0).sumQuantity());
+    assertEquals(sortedEntries.get(1).getKey(), top5ProductsLast3Days.get(1).productId());
+    assertEquals(Long.valueOf(sortedEntries.get(1).getValue()), top5ProductsLast3Days.get(1).sumQuantity());
+    assertEquals(sortedEntries.get(2).getKey(), top5ProductsLast3Days.get(2).productId());
+    assertEquals(Long.valueOf(sortedEntries.get(2).getValue()), top5ProductsLast3Days.get(2).sumQuantity());
+    assertEquals(sortedEntries.get(3).getKey(), top5ProductsLast3Days.get(3).productId());
+    assertEquals(Long.valueOf(sortedEntries.get(3).getValue()), top5ProductsLast3Days.get(3).sumQuantity());
+    assertEquals(sortedEntries.get(4).getKey(), top5ProductsLast3Days.get(4).productId());
+    assertEquals(Long.valueOf(sortedEntries.get(4).getValue()), top5ProductsLast3Days.get(4).sumQuantity());
   }
 
   private List<OrderProduct> getSaveOrderProductList() {

--- a/src/test/java/practice/hhplusecommerce/order/business/OrderServiceTest.java
+++ b/src/test/java/practice/hhplusecommerce/order/business/OrderServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import practice.hhplusecommerce.order.application.dto.request.OrderFacadeRequestDto;
 import practice.hhplusecommerce.order.application.dto.request.OrderFacadeRequestDto.Create;
 import practice.hhplusecommerce.order.application.dto.request.OrderFacadeRequestDto.OrderProductCreate;
+import practice.hhplusecommerce.order.business.command.OrderCommand.Top5ProductsLast3DaysResponse;
 import practice.hhplusecommerce.order.business.entity.Order;
 import practice.hhplusecommerce.order.business.entity.OrderProduct;
 import practice.hhplusecommerce.order.business.repository.OrderProductRepository;
@@ -104,14 +105,14 @@ public class OrderServiceTest {
 
     //when
     when(orderProductRepository.getTop5ProductsLast3Days(any(LocalDateTime.class), any(LocalDateTime.class))).thenReturn(givenList);
-    List<Tuple> whenList = orderService.getTop5ProductsLast3Days();
+    List<Top5ProductsLast3DaysResponse> top5ProductsLast3Days = orderService.getTop5ProductsLast3Days();
 
     //then
     for (int i = 0; i < 1; i++) {
-      assertEquals(givenList.get(i).get("productId"), whenList.get(i).get("productId"));
-      assertEquals(givenList.get(i).get("productName"), whenList.get(i).get("productName"));
-      assertEquals(givenList.get(i).get("productStock"), whenList.get(i).get("productStock"));
-      assertEquals(givenList.get(i).get("productPrice"), whenList.get(i).get("productPrice"));
+      assertEquals(givenList.get(i).get("productId"), top5ProductsLast3Days.get(i).productId());
+      assertEquals(givenList.get(i).get("productName"), top5ProductsLast3Days.get(i).productName());
+      assertEquals(givenList.get(i).get("productStock"), top5ProductsLast3Days.get(i).productStock());
+      assertEquals(givenList.get(i).get("productPrice"), top5ProductsLast3Days.get(i).productPrice());
     }
     verify(orderProductRepository).getTop5ProductsLast3Days(any(LocalDateTime.class), any(LocalDateTime.class));
   }

--- a/src/test/java/practice/hhplusecommerce/product/application/ProductFaçadeIntegrationTest.java
+++ b/src/test/java/practice/hhplusecommerce/product/application/ProductFaçadeIntegrationTest.java
@@ -9,9 +9,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
 import org.springframework.transaction.annotation.Transactional;
 import practice.hhplusecommerce.common.exception.NotFoundException;
 import practice.hhplusecommerce.order.business.entity.Order;
@@ -44,6 +46,14 @@ public class ProductFaçadeIntegrationTest {
   @Autowired
   OrderProductRepository orderProductRepository;
 
+  @Autowired
+  CacheManager cacheManager;
+
+  @BeforeEach
+  public void beforeEach() {
+    cacheManager.getCache("getProductList").clear();
+    cacheManager.getCache("getTop5ProductsLast3Days").clear();
+  }
 
   @Test
   public void 상품목록조회기능_조회되는지_통합테스트() {

--- a/src/test/java/practice/hhplusecommerce/product/application/ProductFaçadeTest.java
+++ b/src/test/java/practice/hhplusecommerce/product/application/ProductFaçadeTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import practice.hhplusecommerce.order.business.command.OrderCommand;
 import practice.hhplusecommerce.order.business.service.OrderService;
 import practice.hhplusecommerce.product.application.dto.response.ProductFacadeResponseDto;
 import practice.hhplusecommerce.product.application.dto.response.ProductFacadeResponseDto.Response;
@@ -92,22 +93,22 @@ public class ProductFaçadeTest {
   public void 상위상품조회시_상위상품조회되는지_테스트() {
 
     // Tuple 객체 생성 및 데이터 설정
-    List<Tuple> tupleList = List.of(
-        new CustomTuple(1L, "상품1", 1000, 50, 10L),
-        new CustomTuple(2L, "상품2", 2000, 30, 5L),
-        new CustomTuple(2L, "상품2", 2000, 30, 5L),
-        new CustomTuple(2L, "상품2", 2000, 30, 5L),
-        new CustomTuple(2L, "상품2", 2000, 30, 5L)
+    List<OrderCommand.Top5ProductsLast3DaysResponse> top5ProductsLast3DaysResponses = List.of(
+        new OrderCommand.Top5ProductsLast3DaysResponse(1L, "상품1", 1000, 50, 10L),
+        new OrderCommand.Top5ProductsLast3DaysResponse(2L, "상품2", 2000, 30, 5L),
+        new OrderCommand.Top5ProductsLast3DaysResponse(2L, "상품2", 2000, 30, 5L),
+        new OrderCommand.Top5ProductsLast3DaysResponse(2L, "상품2", 2000, 30, 5L),
+        new OrderCommand.Top5ProductsLast3DaysResponse(2L, "상품2", 2000, 30, 5L)
     );
 
-    when(orderService.getTop5ProductsLast3Days()).thenReturn(tupleList);
+    when(orderService.getTop5ProductsLast3Days()).thenReturn(top5ProductsLast3DaysResponses);
     List<Top5ProductsLast3DaysResponse> top5ProductsLast3Days = ProductFacade.getTop5ProductsLast3Days();
 
     for (int i = 0; i < 1; i++) {
-      assertEquals(top5ProductsLast3Days.get(i).getProductId(), tupleList.get(i).get("productId"));
-      assertEquals(top5ProductsLast3Days.get(i).getProductName(), tupleList.get(i).get("productName"));
-      assertEquals(top5ProductsLast3Days.get(i).getProductStock(), tupleList.get(i).get("productStock"));
-      assertEquals(top5ProductsLast3Days.get(i).getProductPrice(), tupleList.get(i).get("productPrice"));
+      assertEquals(top5ProductsLast3Days.get(i).getProductId(), top5ProductsLast3DaysResponses.get(i).productId());
+      assertEquals(top5ProductsLast3Days.get(i).getProductName(), top5ProductsLast3DaysResponses.get(i).productName());
+      assertEquals(top5ProductsLast3Days.get(i).getProductStock(), top5ProductsLast3DaysResponses.get(i).productStock());
+      assertEquals(top5ProductsLast3Days.get(i).getProductPrice(), top5ProductsLast3DaysResponses.get(i).productPrice());
     }
     verify(orderService).getTop5ProductsLast3Days();
   }

--- a/src/test/java/practice/hhplusecommerce/product/business/ProductServiceCacheIntegrationTest.java
+++ b/src/test/java/practice/hhplusecommerce/product/business/ProductServiceCacheIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -14,8 +15,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.test.context.ActiveProfiles;
 import practice.hhplusecommerce.common.test.DatabaseCleanUp;
+import practice.hhplusecommerce.product.business.dto.ProductCommand;
+import practice.hhplusecommerce.product.business.dto.ProductCommand.Update;
 import practice.hhplusecommerce.product.business.entity.Product;
 import practice.hhplusecommerce.product.business.repository.ProductRepository;
 import practice.hhplusecommerce.product.business.service.ProductService;
@@ -38,7 +42,6 @@ public class ProductServiceCacheIntegrationTest {
   @Autowired
   CacheManager cacheManager;
 
-
   @BeforeAll
   public void setUpBeforeClass() {
     List<Product> productList = List.of(
@@ -51,8 +54,13 @@ public class ProductServiceCacheIntegrationTest {
     productRepository.saveAll(productList);
   }
 
+  @BeforeEach
+  public void BeforeEach() {
+    cacheManager.getCache("getProductList").clear();
+  }
+
   @AfterAll
-  public void tearDownAfterClass() {
+  public void tearDownAfter() {
     databaseCleanUp.execute();
   }
 
@@ -60,8 +68,6 @@ public class ProductServiceCacheIntegrationTest {
   @DisplayName("상품 목록조회 2번째 조회부터 캐싱되는지 통합테스트")
   public void getProductList_cache_success() {
     //given
-    cacheManager.getCache("getProductList").clear();
-
     //when
     List<Product> productList1 = productService.getProductList();
     List<Product> productList2 = productService.getProductList();
@@ -76,5 +82,43 @@ public class ProductServiceCacheIntegrationTest {
       assertEquals(productList1.get(i).getPrice(), productList2.get(i).getPrice());
       assertEquals(productList1.get(i).getStock(), productList2.get(i).getStock());
     }
+  }
+
+  @Test
+  @DisplayName("상품 수정시 캐싱 제거 되는지 통합테스트")
+  public void updateProduct_CacheEvict_success () {
+    //given
+    String name = "변경된명";
+    int price = 1000;
+    int stock = 1000;
+
+    Product product = new Product(null, "꽃병1", 1500, 5);
+    Product given = productRepository.save(product);
+
+    ProductCommand.Update update = new Update(given.getId(), name, price, stock);
+
+    //when
+    productService.getProductList();
+    productService.updateProduct(update); // 업데트하고 캐싱제거
+    productService.getProductList();
+
+    //then
+    verify(productRepository, times(2)).findAll();
+  }
+
+  @Test
+  @DisplayName("상품 삭제시 캐싱 제거 되는지 통합테스트")
+  public void deleteProduct_CacheEvict_success () {
+    //given
+    Product product = new Product(null, "꽃병1", 1500, 5);
+    Product given = productRepository.save(product);
+
+    //when
+    productService.getProductList();
+    productService.deleteProduct(given.getId()); // 삭제하고 캐싱제거
+    productService.getProductList();
+
+    //then
+    verify(productRepository, times(2)).findAll();
   }
 }

--- a/src/test/java/practice/hhplusecommerce/product/business/ProductServiceCacheIntegrationTest.java
+++ b/src/test/java/practice/hhplusecommerce/product/business/ProductServiceCacheIntegrationTest.java
@@ -1,0 +1,80 @@
+package practice.hhplusecommerce.product.business;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.ActiveProfiles;
+import practice.hhplusecommerce.common.test.DatabaseCleanUp;
+import practice.hhplusecommerce.product.business.entity.Product;
+import practice.hhplusecommerce.product.business.repository.ProductRepository;
+import practice.hhplusecommerce.product.business.service.ProductService;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ProductServiceCacheIntegrationTest {
+
+
+  @Autowired
+  ProductService productService;
+
+  @SpyBean
+  ProductRepository productRepository;
+
+  @Autowired
+  DatabaseCleanUp databaseCleanUp;
+
+  @Autowired
+  CacheManager cacheManager;
+
+
+  @BeforeAll
+  public void setUpBeforeClass() {
+    List<Product> productList = List.of(
+        new Product(null, "꽃병1", 1500, 5),
+        new Product(null, "꽃병2", 1500, 5),
+        new Product(null, "꽃병3", 1500, 5),
+        new Product(null, "꽃병4", 1500, 5),
+        new Product(null, "꽃병5", 1500, 5)
+    );
+    productRepository.saveAll(productList);
+  }
+
+  @AfterAll
+  public void tearDownAfterClass() {
+    databaseCleanUp.execute();
+  }
+
+  @Test
+  @DisplayName("상품 목록조회 2번째 조회부터 캐싱되는지 통합테스트")
+  public void getProductList_cache_success() {
+    //given
+    cacheManager.getCache("getProductList").clear();
+
+    //when
+    List<Product> productList1 = productService.getProductList();
+    List<Product> productList2 = productService.getProductList();
+    productService.getProductList();
+
+    //then
+    verify(productRepository, times(1)).findAll();
+
+    for (int i = 0; i < 5; i++) {
+      assertEquals(productList1.get(i).getId(), productList2.get(i).getId());
+      assertEquals(productList1.get(i).getName(), productList2.get(i).getName());
+      assertEquals(productList1.get(i).getPrice(), productList2.get(i).getPrice());
+      assertEquals(productList1.get(i).getStock(), productList2.get(i).getStock());
+    }
+  }
+}

--- a/src/test/java/practice/hhplusecommerce/user/business/UserServiceTest.java
+++ b/src/test/java/practice/hhplusecommerce/user/business/UserServiceTest.java
@@ -93,7 +93,7 @@ public class UserServiceTest {
 
     //when
     User user = new User(userId, userName, amount);
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(userRepository.findByIdPessimisticLock(userId)).thenReturn(Optional.of(user));
     User when = userService.chargeUserAmount(userId, chargeAmount);
 
     //then
@@ -135,7 +135,7 @@ public class UserServiceTest {
 
     //when
     User user = new User(userId, userName, amount);
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(userRepository.findByIdPessimisticLock(userId)).thenReturn(Optional.of(user));
 
     User when = null;
     Exception e = null;
@@ -161,7 +161,7 @@ public class UserServiceTest {
 
     //when
     User user = new User(userId, userName, amount);
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(userRepository.findByIdPessimisticLock(userId)).thenReturn(Optional.of(user));
 
     User when = null;
     Exception e = null;


### PR DESCRIPTION
# 1. 캐싱
## 캐싱적용한 API 
- 상품목록조회
- 상위상품조회

## 선정 이유
### 인기판매상품조회
인기판매상품조회 같은 경우에는 GROUP BY와 SUM 등 통계쿼리가 발생해 성능적으로 불리한테 이것을 캐싱 처리하게 된다면 많은 이점이 있을 것으로 예상

### 상품목록조회
상품이 추가되거나 삭제되거나 수정되지 않는 이상은 똑같은 데이터가 반환될 것으로 예상되어 상품목록조회도 캐싱처리로 큰 이점을 볼 수 있을 것으로 예상


# 2. 커밋내용 정리
- 레디스를 사용해 캐싱을 처리하기위해 의존성 추가
```
    implementation 'org.springframework.boot:spring-boot-starter-cache'
    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
```
-  상품목록조회에 캐싱처리 후 삭제와 수정 API를 만들어 단위테스부터 ~ 통합테스트까지 작성완료 (Facade계층은 고유로직이 없어서 건너뜀)
- 상위상품조회에 캐싱처리 후 3시간 TTL 을 추가 및 레디스로 캐싱할 때 Tuple 형태로 직렬화가 안되는 이슈가 발생해 Tuple를 command로 convert 하는 과정을 추가함에 따라 관련 테스트코드들 전부 수정


# 3. 리뷰 포인트 

- 기존에 service에서도 request, response DTO를 만들어 convert해서 리턴해줬는데 Service에서는 Command 라는 용어를 사용한다고 들은 후 Command로  convert 해서 리턴해주는 방식으로 수정해봤는데 자세히 생각해보니 Command 라는게 사실 무언가를 실행시키기 위한 요청이라는 뜻이라고 알고 있어서 이렇게 리턴할 때도 Command로 반환해줘도 되는건지?.... 문득 생각이 들었습니다. 코치님의 생각을 듣고싶습니다. 
```java
  @Transactional
  @Cacheable(value = "getTop5ProductsLast3Days")
  public List<OrderCommand.Top5ProductsLast3DaysResponse> getTop5ProductsLast3Days() {
    LocalDateTime now = LocalDateTime.now();
    LocalDateTime minusDays3 = now.minusDays(3);
    List<Tuple> top5ProductsLast3Days = orderProductRepository.getTop5ProductsLast3Days(now, minusDays3);
    return top5ProductsLast3Days.stream().map(OrderCommand.Top5ProductsLast3DaysResponse::new).toList();
  }
```

