### PR TITLE
[Chapter 3-3] 부하를 적절하게 축소하기: STEP 16

### DIFF
--- a/src/main/java/practice/hhplusecommerce/order/application/OrderFacade.java
+++ b/src/main/java/practice/hhplusecommerce/order/application/OrderFacade.java
@@ -5,14 +5,17 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
-import practice.hhplusecommerce.common.exception.BadRequestException;
+import org.springframework.transaction.annotation.Transactional;
 import practice.hhplusecommerce.common.handler.TransactionalHandler;
 import practice.hhplusecommerce.order.application.dto.request.OrderFacadeRequestDto.Create;
 import practice.hhplusecommerce.order.application.dto.request.OrderFacadeRequestDto.OrderProductCreate;
 import practice.hhplusecommerce.order.application.dto.response.OrderFacadeResponseDto.OrderResponse;
 import practice.hhplusecommerce.order.application.dto.response.OrderFacadeResponseDtoMapper;
+import practice.hhplusecommerce.order.business.command.OrderCommand;
 import practice.hhplusecommerce.order.business.entity.Order;
+import practice.hhplusecommerce.order.business.event.DataPlatformEvent;
 import practice.hhplusecommerce.order.business.service.OrderService;
 import practice.hhplusecommerce.order.infrastructure.dataPlatform.DataPlatform;
 import practice.hhplusecommerce.product.business.entity.Product;
@@ -28,14 +31,15 @@ public class OrderFacade {
   private final OrderService orderService;
   private final UserService userService;
   private final ProductService productService;
-  private final DataPlatform dataPlatform;
-  private final TransactionalHandler transactionalHandler;
+  private final ApplicationEventPublisher applicationEventPublisher;
 
   /**
    * 주문과 결제가 같이 진행됩니다.
    */
+  @Transactional
   public OrderResponse order(Long userId, Create create) {
     User user = userService.getUser(userId);
+
     List<Product> productList = productService.getProductListByProductIdList(create.getProductList().stream().map(OrderProductCreate::getId).toList());
 
     int totalProductPrice = 0;
@@ -51,34 +55,19 @@ public class OrderFacade {
       }
     }
 
-    int finalTotalProductPrice = totalProductPrice;
-    Order order = transactionalHandler.runWithTransaction(() -> createOrderAfterDecreaseProductStockAndUserAmount(
-            create,
-            finalTotalProductPrice,
-            userId,
-            productDecreaseStockMap,
-            user,
-            productList
+    productService.decreaseProductsStock(create.getProductList().stream().map(OrderProductCreate::getId).toList(), productDecreaseStockMap);
+    userService.decreaseAmount(userId, totalProductPrice);
+    Order order = orderService.createOrder(totalProductPrice, user, productList, create.getProductList());
+
+    // 데이터플랫폼 이벤트 발행
+    applicationEventPublisher.publishEvent(
+        new DataPlatformEvent(
+            new OrderCommand.SendDataPlatform(order.getId(), order.getUser().getId(), order.getOrderTotalPrice())
         )
     );
-
-    String status = dataPlatform.send(order.getId(), order.getUser().getId(), order.getOrderTotalPrice());
-    if (!status.equals("OK 200")) {
-      log.error("OrderFacade.order status : {}", status);
-      throw new BadRequestException("주문정보를 데이처플랫폼에 전송 실패했습니다.");
-    }
 
     OrderResponse orderResponse = OrderFacadeResponseDtoMapper.toOrderResponse(order);
     orderResponse.setOrderProductList(order.getOrderProductList().stream().map(OrderFacadeResponseDtoMapper::toOrderProductResponse).toList());
     return orderResponse;
-  }
-
-  /**
-   * 최소 단위로 트랜잭션을 걸고 싶어서 분리
-   */
-  private Order createOrderAfterDecreaseProductStockAndUserAmount(Create create, int totalProductPrice, Long userId, Map<Long, Integer> productDecreaseStockMap, User user, List<Product> productList) {
-    productService.decreaseProductsStock(create.getProductList().stream().map(OrderProductCreate::getId).toList(), productDecreaseStockMap);
-    userService.decreaseAmount(userId, totalProductPrice);
-    return orderService.createOrder(totalProductPrice, user, productList, create.getProductList());
   }
 }

--- a/src/main/java/practice/hhplusecommerce/order/application/listener/DataPlatformEventListener.java
+++ b/src/main/java/practice/hhplusecommerce/order/application/listener/DataPlatformEventListener.java
@@ -1,0 +1,30 @@
+package practice.hhplusecommerce.order.application.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import practice.hhplusecommerce.common.exception.BadRequestException;
+import practice.hhplusecommerce.order.business.event.DataPlatformEvent;
+import practice.hhplusecommerce.order.infrastructure.dataPlatform.DataPlatform;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DataPlatformEventListener {
+
+  private final DataPlatform dataPlatform;
+
+  @Async
+  @EventListener
+  public void handleSendDataPlatformEvent(DataPlatformEvent dataPlatformEvent) {
+    String status = dataPlatform.send(dataPlatformEvent.getOrderId(), dataPlatformEvent.getUserId(), dataPlatformEvent.getOrderTotalPrice());
+    log.info("OrderFacade.order status : {}", status);
+
+    if (!status.equals("OK 200")) {
+      log.error("OrderFacade.order status : {}", status);
+      throw new BadRequestException("주문정보를 데이처플랫폼에 전송 실패했습니다.");
+    }
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/order/application/listener/DataPlatformEventListener.java
+++ b/src/main/java/practice/hhplusecommerce/order/application/listener/DataPlatformEventListener.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import practice.hhplusecommerce.common.exception.BadRequestException;
 import practice.hhplusecommerce.order.business.event.DataPlatformEvent;
 import practice.hhplusecommerce.order.infrastructure.dataPlatform.DataPlatform;
@@ -17,7 +19,7 @@ public class DataPlatformEventListener {
   private final DataPlatform dataPlatform;
 
   @Async
-  @EventListener
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handleSendDataPlatformEvent(DataPlatformEvent dataPlatformEvent) {
     String status = dataPlatform.send(dataPlatformEvent.getOrderId(), dataPlatformEvent.getUserId(), dataPlatformEvent.getOrderTotalPrice());
     log.info("OrderFacade.order status : {}", status);

--- a/src/main/java/practice/hhplusecommerce/order/business/command/OrderCommand.java
+++ b/src/main/java/practice/hhplusecommerce/order/business/command/OrderCommand.java
@@ -30,4 +30,17 @@ public class OrderCommand {
       );
     }
   }
+
+  public record SendDataPlatform(
+      Long orderId,
+      Long userId,
+      Integer orderTotalPrice
+  ){
+
+    public SendDataPlatform(Long orderId, Long userId, Integer orderTotalPrice) {
+      this.orderId = orderId;
+      this.userId = userId;
+      this.orderTotalPrice = orderTotalPrice;
+    }
+  }
 }

--- a/src/main/java/practice/hhplusecommerce/order/business/event/DataPlatformEvent.java
+++ b/src/main/java/practice/hhplusecommerce/order/business/event/DataPlatformEvent.java
@@ -1,0 +1,18 @@
+package practice.hhplusecommerce.order.business.event;
+
+import lombok.Getter;
+import practice.hhplusecommerce.order.business.command.OrderCommand;
+
+@Getter
+public class DataPlatformEvent {
+
+ private final Long orderId;
+ private final Long userId;
+ private final Integer orderTotalPrice;
+
+  public DataPlatformEvent(OrderCommand.SendDataPlatform sendDataPlatform) {
+    this.orderId = sendDataPlatform.orderId();
+    this.userId = sendDataPlatform.userId();
+    this.orderTotalPrice = sendDataPlatform.orderTotalPrice();
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/order/infrastructure/dataPlatform/DataPlatform.java
+++ b/src/main/java/practice/hhplusecommerce/order/infrastructure/dataPlatform/DataPlatform.java
@@ -1,10 +1,10 @@
 package practice.hhplusecommerce.order.infrastructure.dataPlatform;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 @Slf4j
-@Service
+@Component
 public class DataPlatform {
 
   public String send(Long id, Long userId, Integer orderTotalPrice) {

--- a/src/test/java/practice/hhplusecommerce/order/application/OrderFacadeIntegrationTest.java
+++ b/src/test/java/practice/hhplusecommerce/order/application/OrderFacadeIntegrationTest.java
@@ -56,10 +56,9 @@ public class OrderFacadeIntegrationTest {
   private OrderProductRepository orderProductRepository;
 
   @Test
-  @Transactional
   public void 주문기능_주문되는지_통합테스트() {
     //given
-    String userName = "백현";
+    String userName = "백현1";
     int amount = 5500;
     int price1 = 500;
     int price2 = 400;
@@ -105,6 +104,9 @@ public class OrderFacadeIntegrationTest {
     }
 
     assertEquals(orderProductList.size(), order.getOrderProductList().size());
+
+    userRepository.delete(saveUser);
+    productRepository.deleteAllInBatch(saveProductList);
   }
 
   @Test


### PR DESCRIPTION
# [Chapter 3-3] 부하를 적절하게 축소하기
### 1. Step 16-1

 [서비스 MSA 분리 설계 문서.md](https://github.com/whitewise95/hhplus-e-commerce/blob/main/docs/%EC%84%9C%EB%B9%84%EC%8A%A4%20MSA%20%EB%B6%84%EB%A6%AC%20%EC%84%A4%EA%B3%84%20%EB%AC%B8%EC%84%9C.md)



###  2. Step 16-2
[4f7ceb7](https://github.com/whitewise95/hhplus-e-commerce/pull/9/commits/4f7ceb7341643fac158103208f7b74f1efc7792f)  - 데이터 플랫폼에 전송하는 로직 `@eventlistener`적용
[db2f72a](https://github.com/whitewise95/hhplus-e-commerce/pull/9/commits/db2f72ac0fd5f7972cd57f5f5d19d58c64e88294) - `@eventlistener` => `@TransactionalEventListener` 로 수정하고 커밋 이후에 이벤트가 발생할 수 있도록 `AFTER_COMMIT` 적용



# 리뷰 포인트
1. listener, event 를 정확한 계층에 두었는지 모르겠습니다..
`listener`는 `application 계층`
`evnet`는 `business 계층(domain)`에 두었습니다. 
![image](https://github.com/user-attachments/assets/da6895be-a36f-428a-8027-e61860a6f36e)


2. 유저 정보조회 및 잔액조회와 상품 정보조회 및 상품 재고조회를 이벤트가 아니라 RestAPI를 통해서 하는걸로 생각해봤는데 옳은 방법인지 모르겠습니다.
<img width="922" alt="image" src="https://github.com/user-attachments/assets/ca53a248-3e1e-4524-b6d5-0c79fe6d990c">



