### PR TITLE
[Chapter 3-4] 책임 분리를 통한 애플리케이션 설계_ step_17_18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,13 @@ dependencies {
     //redis and cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
+
 }
 
 tasks.named('test') {

--- a/kafka-docker-compose.yml
+++ b/kafka-docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3'
+services:
+  zookeeper:
+    image: 'confluentinc/cp-zookeeper:7.4.0'
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+    networks:
+      - kafka-net
+
+  kafka:
+    image: 'confluentinc/cp-kafka:7.4.0'
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:9093,OUTSIDE://localhost:9092
+      KAFKA_LISTENER_NAMES: INSIDE,OUTSIDE
+      KAFKA_LISTENERS: INSIDE://0.0.0.0:9093,OUTSIDE://0.0.0.0:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'  # auto.create.topics.enable 설정
+
+    networks:
+      - kafka-net
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    depends_on:
+      - kafka
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=local
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9093
+      - KAFKA_CLUSTERS_0_ZOOKEEPER=zookeeper:2181
+    ports:
+      - "8081:8080"
+    networks:
+      - kafka-net
+
+networks:
+  kafka-net:
+    driver: bridge

--- a/src/main/java/practice/hhplusecommerce/HhplusECommerceApplication.java
+++ b/src/main/java/practice/hhplusecommerce/HhplusECommerceApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @ServletComponentScan
 @SpringBootApplication

--- a/src/main/java/practice/hhplusecommerce/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/practice/hhplusecommerce/common/config/KafkaConsumerConfig.java
@@ -1,0 +1,55 @@
+package practice.hhplusecommerce.common.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import practice.hhplusecommerce.order.business.event.DataPlatformEvent;
+
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, String> dataPlatformListenerFactory() {
+    ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    factory.setConcurrency(1);
+    factory.getContainerProperties().setAckTime(3000);
+    factory.getContainerProperties().setPollTimeout(500);
+    factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(getConsumerConfig("data_platform_group")));
+    factory.getContainerProperties().setLogContainerConfig(true);
+    factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+    return factory;
+  }
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, String> dataPlatformOutBoxListenerFactory() {
+    ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    factory.setConcurrency(1);
+    factory.getContainerProperties().setAckTime(3000);
+    factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(getConsumerConfig("outbox_group")));
+    factory.getContainerProperties().setPollTimeout(500);
+    factory.getContainerProperties().setLogContainerConfig(true);
+    factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+    return factory;
+  }
+
+  private Map<String, Object> getConsumerConfig(String group) {
+    Map<String, Object> consumerConfig = new HashMap<>();
+    consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, group);
+    consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    consumerConfig.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // Adjust this as needed
+    consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    consumerConfig.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+    return consumerConfig;
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/common/config/KafkaProducerConfig.java
+++ b/src/main/java/practice/hhplusecommerce/common/config/KafkaProducerConfig.java
@@ -1,0 +1,31 @@
+package practice.hhplusecommerce.common.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import practice.hhplusecommerce.order.business.event.DataPlatformEvent;
+
+@Configuration
+public class KafkaProducerConfig {
+
+  @Bean
+  public ProducerFactory<String, DataPlatformEvent> producerFactory() {
+    Map<String, Object> props = new HashMap<>();
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    return new DefaultKafkaProducerFactory<>(props);
+  }
+
+  @Bean
+  public KafkaTemplate<String, DataPlatformEvent> kafkaTemplate() {
+    return new KafkaTemplate<>(producerFactory());
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/order/application/OrderFacade.java
+++ b/src/main/java/practice/hhplusecommerce/order/application/OrderFacade.java
@@ -1,5 +1,7 @@
 package practice.hhplusecommerce.order.application;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -8,9 +10,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import practice.hhplusecommerce.common.handler.TransactionalHandler;
+import practice.hhplusecommerce.common.exception.BadRequestException;
 import practice.hhplusecommerce.order.application.dto.request.OrderFacadeRequestDto.Create;
 import practice.hhplusecommerce.order.application.dto.request.OrderFacadeRequestDto.OrderProductCreate;
+import practice.hhplusecommerce.order.application.dto.request.OrderFacadeRequestDto.SendDataPlatform;
 import practice.hhplusecommerce.order.application.dto.response.OrderFacadeResponseDto.OrderResponse;
 import practice.hhplusecommerce.order.application.dto.response.OrderFacadeResponseDtoMapper;
 import practice.hhplusecommerce.order.business.command.OrderCommand;
@@ -18,6 +21,9 @@ import practice.hhplusecommerce.order.business.entity.Order;
 import practice.hhplusecommerce.order.business.event.DataPlatformEvent;
 import practice.hhplusecommerce.order.business.service.OrderService;
 import practice.hhplusecommerce.order.infrastructure.dataPlatform.DataPlatform;
+import practice.hhplusecommerce.outbox.business.entity.Outbox;
+import practice.hhplusecommerce.outbox.business.entity.enums.OutboxType;
+import practice.hhplusecommerce.outbox.business.service.OutboxService;
 import practice.hhplusecommerce.product.business.entity.Product;
 import practice.hhplusecommerce.product.business.service.ProductService;
 import practice.hhplusecommerce.user.business.entity.User;
@@ -31,6 +37,8 @@ public class OrderFacade {
   private final OrderService orderService;
   private final UserService userService;
   private final ProductService productService;
+  private final OutboxService outboxService;
+  private final DataPlatform dataPlatform;
   private final ApplicationEventPublisher applicationEventPublisher;
 
   /**
@@ -59,15 +67,40 @@ public class OrderFacade {
     userService.decreaseAmount(userId, totalProductPrice);
     Order order = orderService.createOrder(totalProductPrice, user, productList, create.getProductList());
 
-    // 데이터플랫폼 이벤트 발행
-    applicationEventPublisher.publishEvent(
-        new DataPlatformEvent(
-            new OrderCommand.SendDataPlatform(order.getId(), order.getUser().getId(), order.getOrderTotalPrice())
+    Outbox outbox = outboxService.create(OutboxType.DATA_PLATFORM);
+    DataPlatformEvent dataPlatformEvent = new DataPlatformEvent(
+        new OrderCommand.SendDataPlatform(
+            order.getId(),
+            order.getUser().getId(),
+            order.getOrderTotalPrice(),
+            outbox.getId()
         )
     );
+
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      outbox.saveMessage(objectMapper.writeValueAsString(dataPlatformEvent));
+    }catch (JsonProcessingException e) {
+      log.error("OrderFacade JsonProcessingException : {}", e.getMessage());
+       e.printStackTrace();
+    }
+
+    // 데이터플랫폼 이벤트 발행
+    applicationEventPublisher.publishEvent(dataPlatformEvent);
 
     OrderResponse orderResponse = OrderFacadeResponseDtoMapper.toOrderResponse(order);
     orderResponse.setOrderProductList(order.getOrderProductList().stream().map(OrderFacadeResponseDtoMapper::toOrderProductResponse).toList());
     return orderResponse;
+  }
+
+  public void sendDataPlatform(SendDataPlatform sendDataPlatform) {
+    String status = dataPlatform.send(sendDataPlatform.getOrderId(), sendDataPlatform.getUserId(), sendDataPlatform.getOrderTotalPrice());
+
+    log.info("OrderFacade.order status : {}", status);
+
+    if (!status.equals("OK 200")) {
+      log.error("OrderFacade.order status : {}", status);
+      throw new BadRequestException("주문정보를 데이처플랫폼에 전송 실패했습니다.");
+    }
   }
 }

--- a/src/main/java/practice/hhplusecommerce/order/application/dto/request/OrderFacadeRequestDto.java
+++ b/src/main/java/practice/hhplusecommerce/order/application/dto/request/OrderFacadeRequestDto.java
@@ -3,9 +3,11 @@ package practice.hhplusecommerce.order.application.dto.request;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 public class OrderFacadeRequestDto {
+
 
   @Getter
   @Setter
@@ -20,5 +22,20 @@ public class OrderFacadeRequestDto {
 
     private Long id;
     private Integer quantity;
+  }
+
+  @Getter
+  @NoArgsConstructor
+  public static class SendDataPlatform {
+
+    private Long orderId;
+    private Long userId;
+    private Integer orderTotalPrice;
+
+    public SendDataPlatform(Long orderId, Long userId, Integer orderTotalPrice) {
+      this.orderId = orderId;
+      this.userId = userId;
+      this.orderTotalPrice = orderTotalPrice;
+    }
   }
 }

--- a/src/main/java/practice/hhplusecommerce/order/application/listener/DataPlatformEventListener.java
+++ b/src/main/java/practice/hhplusecommerce/order/application/listener/DataPlatformEventListener.java
@@ -2,13 +2,12 @@ package practice.hhplusecommerce.order.application.listener;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
-import practice.hhplusecommerce.common.exception.BadRequestException;
 import practice.hhplusecommerce.order.business.event.DataPlatformEvent;
+import practice.hhplusecommerce.order.business.publisher.OrderMessagePublisher;
 import practice.hhplusecommerce.order.infrastructure.dataPlatform.DataPlatform;
 
 @Slf4j
@@ -17,16 +16,11 @@ import practice.hhplusecommerce.order.infrastructure.dataPlatform.DataPlatform;
 public class DataPlatformEventListener {
 
   private final DataPlatform dataPlatform;
+  private final OrderMessagePublisher orderMessagePublisher;
 
   @Async
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handleSendDataPlatformEvent(DataPlatformEvent dataPlatformEvent) {
-    String status = dataPlatform.send(dataPlatformEvent.getOrderId(), dataPlatformEvent.getUserId(), dataPlatformEvent.getOrderTotalPrice());
-    log.info("OrderFacade.order status : {}", status);
-
-    if (!status.equals("OK 200")) {
-      log.error("OrderFacade.order status : {}", status);
-      throw new BadRequestException("주문정보를 데이처플랫폼에 전송 실패했습니다.");
-    }
+    orderMessagePublisher.publish(dataPlatformEvent);
   }
 }

--- a/src/main/java/practice/hhplusecommerce/order/business/command/OrderCommand.java
+++ b/src/main/java/practice/hhplusecommerce/order/business/command/OrderCommand.java
@@ -34,13 +34,15 @@ public class OrderCommand {
   public record SendDataPlatform(
       Long orderId,
       Long userId,
-      Integer orderTotalPrice
-  ){
+      Integer orderTotalPrice,
+      Long outboxId
+  ) {
 
-    public SendDataPlatform(Long orderId, Long userId, Integer orderTotalPrice) {
+    public SendDataPlatform(Long orderId, Long userId, Integer orderTotalPrice, Long outboxId) {
       this.orderId = orderId;
       this.userId = userId;
       this.orderTotalPrice = orderTotalPrice;
+      this.outboxId = outboxId;
     }
   }
 }

--- a/src/main/java/practice/hhplusecommerce/order/business/event/DataPlatformEvent.java
+++ b/src/main/java/practice/hhplusecommerce/order/business/event/DataPlatformEvent.java
@@ -1,18 +1,37 @@
 package practice.hhplusecommerce.order.business.event;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.ToString;
 import practice.hhplusecommerce.order.business.command.OrderCommand;
 
 @Getter
+@ToString
 public class DataPlatformEvent {
 
- private final Long orderId;
- private final Long userId;
- private final Integer orderTotalPrice;
+  private final Long orderId;
+  private final Long userId;
+  private final Integer orderTotalPrice;
+  private final Long outboxId;
 
+  @JsonCreator
+  public DataPlatformEvent(
+      @JsonProperty("orderId") Long orderId,
+      @JsonProperty("userId") Long userId,
+      @JsonProperty("orderTotalPrice") Integer orderTotalPrice,
+      @JsonProperty("outboxId") Long outboxId) {
+    this.orderId = orderId;
+    this.userId = userId;
+    this.orderTotalPrice = orderTotalPrice;
+    this.outboxId = outboxId;
+  }
+
+  // 기존 생성자 유지
   public DataPlatformEvent(OrderCommand.SendDataPlatform sendDataPlatform) {
     this.orderId = sendDataPlatform.orderId();
     this.userId = sendDataPlatform.userId();
     this.orderTotalPrice = sendDataPlatform.orderTotalPrice();
+    this.outboxId = sendDataPlatform.outboxId();
   }
 }

--- a/src/main/java/practice/hhplusecommerce/order/business/publisher/OrderMessagePublisher.java
+++ b/src/main/java/practice/hhplusecommerce/order/business/publisher/OrderMessagePublisher.java
@@ -1,0 +1,8 @@
+package practice.hhplusecommerce.order.business.publisher;
+
+import practice.hhplusecommerce.order.business.event.DataPlatformEvent;
+
+public interface OrderMessagePublisher {
+
+  void publish(DataPlatformEvent dataPlatformEvent);
+}

--- a/src/main/java/practice/hhplusecommerce/order/infrastructure/kafka/OrderMessageProducer.java
+++ b/src/main/java/practice/hhplusecommerce/order/infrastructure/kafka/OrderMessageProducer.java
@@ -1,0 +1,23 @@
+package practice.hhplusecommerce.order.infrastructure.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import practice.hhplusecommerce.order.business.event.DataPlatformEvent;
+import practice.hhplusecommerce.order.business.publisher.OrderMessagePublisher;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderMessageProducer implements OrderMessagePublisher {
+
+  private final KafkaTemplate<String, DataPlatformEvent> kafkaTemplate;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void publish(DataPlatformEvent dataPlatformEvent) {
+    kafkaTemplate.send("order_topic", dataPlatformEvent);
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/order/presentation/consumer/DataPlatformConsumer.java
+++ b/src/main/java/practice/hhplusecommerce/order/presentation/consumer/DataPlatformConsumer.java
@@ -1,0 +1,40 @@
+package practice.hhplusecommerce.order.presentation.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import practice.hhplusecommerce.order.application.OrderFacade;
+import practice.hhplusecommerce.order.application.dto.request.OrderFacadeRequestDto;
+import practice.hhplusecommerce.order.business.event.DataPlatformEvent;
+
+@Slf4j
+@Component
+@Getter
+@RequiredArgsConstructor
+public class DataPlatformConsumer {
+
+  private ObjectMapper objectMapper = new ObjectMapper();
+  private final BlockingQueue<DataPlatformEvent> records = new LinkedBlockingQueue<>();
+  private final OrderFacade orderFacade;
+
+  @KafkaListener(topics = "order_topic", containerFactory = "dataPlatformListenerFactory", groupId = "data_platform_group")
+  private void dataPlatformListener(ConsumerRecord<String, String> consumerRecord, Acknowledgment acknowledgment) {
+    try {
+      DataPlatformEvent dataPlatformEvent = objectMapper.readValue(consumerRecord.value(), DataPlatformEvent.class);
+      log.info("dataPlatformOutboxListener message : {}", dataPlatformEvent.toString());
+      records.add(dataPlatformEvent); // 메시지를 BlockingQueue에 저장
+      orderFacade.sendDataPlatform(new OrderFacadeRequestDto.SendDataPlatform(dataPlatformEvent.getOrderId(), dataPlatformEvent.getUserId(), dataPlatformEvent.getOrderTotalPrice()));
+    } catch (JsonProcessingException jpe) {
+      log.error("dataPlatformOutboxListener error : {}", jpe.getMessage());
+      jpe.printStackTrace();
+    }
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/order/presentation/consumer/OutboxConsumer.java
+++ b/src/main/java/practice/hhplusecommerce/order/presentation/consumer/OutboxConsumer.java
@@ -1,0 +1,36 @@
+package practice.hhplusecommerce.order.presentation.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import practice.hhplusecommerce.order.business.event.DataPlatformEvent;
+import practice.hhplusecommerce.outbox.business.service.OutboxService;
+
+@Slf4j
+@Getter
+@Component
+@RequiredArgsConstructor
+public class OutboxConsumer {
+
+  private final OutboxService outboxService;
+  private ObjectMapper objectMapper = new ObjectMapper();
+
+  @KafkaListener(topics = "order_topic", containerFactory = "dataPlatformOutBoxListenerFactory", groupId = "outbox_group")
+  private void dataPlatformOutboxListener(ConsumerRecord<String, String> consumerRecord) {
+    try {
+      DataPlatformEvent dataPlatformEvent = objectMapper.readValue(consumerRecord.value(), DataPlatformEvent.class);
+      log.info("message {}", dataPlatformEvent.getOutboxId());
+      outboxService.updateState(dataPlatformEvent.getOutboxId());
+    } catch (JsonProcessingException jpe) {
+      log.error("dataPlatformOutboxListener error : {}", jpe.getMessage());
+      jpe.printStackTrace();
+    }
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/order/presentation/scheduler/OrderScheduler.java
+++ b/src/main/java/practice/hhplusecommerce/order/presentation/scheduler/OrderScheduler.java
@@ -1,0 +1,39 @@
+package practice.hhplusecommerce.order.presentation.scheduler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import practice.hhplusecommerce.order.business.event.DataPlatformEvent;
+import practice.hhplusecommerce.outbox.business.entity.Outbox;
+import practice.hhplusecommerce.outbox.business.repository.OutboxRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderScheduler {
+
+  private final OutboxRepository outboxRepository;
+  private final ApplicationEventPublisher applicationEventPublisher;
+
+  @Scheduled(fixedDelay = 10000)
+  @Transactional
+  public void retryDataPlatformEvent() throws JsonProcessingException {
+    LocalDateTime localDateTimeOf5MinutesAgo = LocalDateTime.now().minusMinutes(5);
+    List<Outbox> outboxList = outboxRepository.findAllByFailEvent(localDateTimeOf5MinutesAgo);
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    for (Outbox outbox : outboxList) {
+      outbox.retry();
+      DataPlatformEvent dataPlatformEvent = objectMapper.readValue(outbox.getMessage(), DataPlatformEvent.class);
+      applicationEventPublisher.publishEvent(dataPlatformEvent);
+    }
+  }
+
+}

--- a/src/main/java/practice/hhplusecommerce/order/presentation/scheduler/OrderScheduler.java
+++ b/src/main/java/practice/hhplusecommerce/order/presentation/scheduler/OrderScheduler.java
@@ -24,7 +24,7 @@ public class OrderScheduler {
 
   @Scheduled(fixedDelay = 10000)
   @Transactional
-  public void retryDataPlatformEvent() throws JsonProcessingException {
+  public void retryOutboxEvent() throws JsonProcessingException {
     LocalDateTime localDateTimeOf5MinutesAgo = LocalDateTime.now().minusMinutes(5);
     List<Outbox> outboxList = outboxRepository.findAllByFailEvent(localDateTimeOf5MinutesAgo);
 
@@ -34,6 +34,13 @@ public class OrderScheduler {
       DataPlatformEvent dataPlatformEvent = objectMapper.readValue(outbox.getMessage(), DataPlatformEvent.class);
       applicationEventPublisher.publishEvent(dataPlatformEvent);
     }
+  }
+
+  @Scheduled(cron = "0 0 0 * * *")
+  @Transactional
+  public void removeOutboxStaleData() {
+    LocalDateTime localDateTimeOf1DaysAgo = LocalDateTime.now().minusDays(1);
+    outboxRepository.deleteAllOutboxStaleData(localDateTimeOf1DaysAgo);
   }
 
 }

--- a/src/main/java/practice/hhplusecommerce/outbox/business/entity/Outbox.java
+++ b/src/main/java/practice/hhplusecommerce/outbox/business/entity/Outbox.java
@@ -1,0 +1,53 @@
+package practice.hhplusecommerce.outbox.business.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import practice.hhplusecommerce.common.baseEntity.BaseLocalDateTimeEntity;
+import practice.hhplusecommerce.outbox.business.entity.enums.OutboxState;
+import practice.hhplusecommerce.outbox.business.entity.enums.OutboxType;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Outbox extends BaseLocalDateTimeEntity {
+
+  @Id
+  @Comment("고유번호")
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Comment("메시지")
+  private String message;
+
+  @NotNull
+  @Comment("타입")
+  @Enumerated(EnumType.STRING)
+  private OutboxType type;
+
+  @NotNull
+  @Comment("상태")
+  @Enumerated(EnumType.STRING)
+  private OutboxState state;
+
+  public Outbox(OutboxType type) {
+    this.type = type;
+    this.state = OutboxState.INIT;
+  }
+
+  public void publish() {
+    this.state = OutboxState.PUBLISH;
+  }
+
+  public void saveMessage(String message) {
+    this.message = message;
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/outbox/business/entity/Outbox.java
+++ b/src/main/java/practice/hhplusecommerce/outbox/business/entity/Outbox.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Comment;
 import practice.hhplusecommerce.common.baseEntity.BaseLocalDateTimeEntity;
 import practice.hhplusecommerce.outbox.business.entity.enums.OutboxState;
@@ -27,6 +28,10 @@ public class Outbox extends BaseLocalDateTimeEntity {
 
   @Comment("메시지")
   private String message;
+
+  @Comment("재시도 횟수")
+  @ColumnDefault("0")
+  private Integer retryCount;
 
   @NotNull
   @Comment("타입")
@@ -49,5 +54,9 @@ public class Outbox extends BaseLocalDateTimeEntity {
 
   public void saveMessage(String message) {
     this.message = message;
+  }
+
+  public void retry() {
+    retryCount = retryCount + 1;
   }
 }

--- a/src/main/java/practice/hhplusecommerce/outbox/business/entity/enums/OutboxState.java
+++ b/src/main/java/practice/hhplusecommerce/outbox/business/entity/enums/OutboxState.java
@@ -1,0 +1,16 @@
+package practice.hhplusecommerce.outbox.business.entity.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum OutboxState {
+
+  INIT("생성"),
+  PUBLISH("발행");
+
+  private final String label;
+
+  OutboxState(String label) {
+    this.label = label;
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/outbox/business/entity/enums/OutboxType.java
+++ b/src/main/java/practice/hhplusecommerce/outbox/business/entity/enums/OutboxType.java
@@ -1,0 +1,15 @@
+package practice.hhplusecommerce.outbox.business.entity.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum OutboxType {
+
+  DATA_PLATFORM("데이터플랫폼");
+
+  private final String label;
+
+  OutboxType(String label) {
+    this.label = label;
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/outbox/business/repository/OutboxRepository.java
+++ b/src/main/java/practice/hhplusecommerce/outbox/business/repository/OutboxRepository.java
@@ -12,4 +12,6 @@ public interface OutboxRepository {
   Optional<Outbox> findById(Long outboxId);
 
   List<Outbox> findAllByFailEvent(LocalDateTime localDateTimeOf5MinutesAgo);
+
+  void deleteAllOutboxStaleData(LocalDateTime localDateTimeOf1DaysAgo);
 }

--- a/src/main/java/practice/hhplusecommerce/outbox/business/repository/OutboxRepository.java
+++ b/src/main/java/practice/hhplusecommerce/outbox/business/repository/OutboxRepository.java
@@ -1,5 +1,7 @@
 package practice.hhplusecommerce.outbox.business.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import practice.hhplusecommerce.outbox.business.entity.Outbox;
 
@@ -8,4 +10,6 @@ public interface OutboxRepository {
   Outbox save(Outbox outbox);
 
   Optional<Outbox> findById(Long outboxId);
+
+  List<Outbox> findAllByFailEvent(LocalDateTime localDateTimeOf5MinutesAgo);
 }

--- a/src/main/java/practice/hhplusecommerce/outbox/business/repository/OutboxRepository.java
+++ b/src/main/java/practice/hhplusecommerce/outbox/business/repository/OutboxRepository.java
@@ -1,0 +1,11 @@
+package practice.hhplusecommerce.outbox.business.repository;
+
+import java.util.Optional;
+import practice.hhplusecommerce.outbox.business.entity.Outbox;
+
+public interface OutboxRepository {
+
+  Outbox save(Outbox outbox);
+
+  Optional<Outbox> findById(Long outboxId);
+}

--- a/src/main/java/practice/hhplusecommerce/outbox/business/service/OutboxService.java
+++ b/src/main/java/practice/hhplusecommerce/outbox/business/service/OutboxService.java
@@ -1,0 +1,33 @@
+package practice.hhplusecommerce.outbox.business.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import practice.hhplusecommerce.common.exception.NotFoundException;
+import practice.hhplusecommerce.outbox.business.entity.Outbox;
+import practice.hhplusecommerce.outbox.business.entity.enums.OutboxType;
+import practice.hhplusecommerce.outbox.business.repository.OutboxRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboxService {
+
+  private final OutboxRepository outboxRepository;
+
+  @Transactional
+  public Outbox create(OutboxType type) {
+    return outboxRepository.save(new Outbox(type));
+  }
+
+  @Transactional
+  public void updateState(Long outboxId) {
+    Outbox outbox = outboxRepository.findById(outboxId).orElseThrow(() -> {
+      log.error("outbox get Error id :{}", outboxId);
+      return new NotFoundException("아웃박스", true);
+    });
+
+    outbox.publish();
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/outbox/infrastructure/repository/OutboxJpaRepository.java
+++ b/src/main/java/practice/hhplusecommerce/outbox/infrastructure/repository/OutboxJpaRepository.java
@@ -3,6 +3,7 @@ package practice.hhplusecommerce.outbox.infrastructure.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import practice.hhplusecommerce.outbox.business.entity.Outbox;
 
@@ -10,4 +11,8 @@ public interface OutboxJpaRepository extends JpaRepository<Outbox, Long> {
 
   @Query("SELECT o FROM Outbox o WHERE o.state = 'INIT' AND o.createdAt < :localDateTime AND o.updatedAt < :localDateTime")
   List<Outbox> findAllByFailEvent(LocalDateTime localDateTime);
+
+  @Modifying
+  @Query("DELETE FROM Outbox  WHERE createdAt < :localDateTime AND updatedAt < :localDateTime")
+  void deleteAllOutboxStaleData(LocalDateTime localDateTime);
 }

--- a/src/main/java/practice/hhplusecommerce/outbox/infrastructure/repository/OutboxJpaRepository.java
+++ b/src/main/java/practice/hhplusecommerce/outbox/infrastructure/repository/OutboxJpaRepository.java
@@ -1,0 +1,8 @@
+package practice.hhplusecommerce.outbox.infrastructure.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import practice.hhplusecommerce.outbox.business.entity.Outbox;
+
+public interface OutboxJpaRepository extends JpaRepository<Outbox, Long> {
+
+}

--- a/src/main/java/practice/hhplusecommerce/outbox/infrastructure/repository/OutboxJpaRepository.java
+++ b/src/main/java/practice/hhplusecommerce/outbox/infrastructure/repository/OutboxJpaRepository.java
@@ -1,8 +1,13 @@
 package practice.hhplusecommerce.outbox.infrastructure.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import practice.hhplusecommerce.outbox.business.entity.Outbox;
 
 public interface OutboxJpaRepository extends JpaRepository<Outbox, Long> {
 
+  @Query("SELECT o FROM Outbox o WHERE o.state = 'INIT' AND o.createdAt < :localDateTime AND o.updatedAt < :localDateTime")
+  List<Outbox> findAllByFailEvent(LocalDateTime localDateTime);
 }

--- a/src/main/java/practice/hhplusecommerce/outbox/infrastructure/repository/OutboxRepositoryImpl.java
+++ b/src/main/java/practice/hhplusecommerce/outbox/infrastructure/repository/OutboxRepositoryImpl.java
@@ -1,0 +1,24 @@
+package practice.hhplusecommerce.outbox.infrastructure.repository;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import practice.hhplusecommerce.outbox.business.entity.Outbox;
+import practice.hhplusecommerce.outbox.business.repository.OutboxRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryImpl implements OutboxRepository {
+
+  private final OutboxJpaRepository outboxJpaRepository;
+
+  @Override
+  public Outbox save(Outbox outbox) {
+    return outboxJpaRepository.save(outbox);
+  }
+
+  @Override
+  public Optional<Outbox> findById(Long outboxId) {
+    return outboxJpaRepository.findById(outboxId);
+  }
+}

--- a/src/main/java/practice/hhplusecommerce/outbox/infrastructure/repository/OutboxRepositoryImpl.java
+++ b/src/main/java/practice/hhplusecommerce/outbox/infrastructure/repository/OutboxRepositoryImpl.java
@@ -1,5 +1,7 @@
 package practice.hhplusecommerce.outbox.infrastructure.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -20,5 +22,10 @@ public class OutboxRepositoryImpl implements OutboxRepository {
   @Override
   public Optional<Outbox> findById(Long outboxId) {
     return outboxJpaRepository.findById(outboxId);
+  }
+
+  @Override
+  public List<Outbox> findAllByFailEvent(LocalDateTime localDateTime) {
+    return outboxJpaRepository.findAllByFailEvent(localDateTime);
   }
 }

--- a/src/main/java/practice/hhplusecommerce/outbox/infrastructure/repository/OutboxRepositoryImpl.java
+++ b/src/main/java/practice/hhplusecommerce/outbox/infrastructure/repository/OutboxRepositoryImpl.java
@@ -28,4 +28,9 @@ public class OutboxRepositoryImpl implements OutboxRepository {
   public List<Outbox> findAllByFailEvent(LocalDateTime localDateTime) {
     return outboxJpaRepository.findAllByFailEvent(localDateTime);
   }
+
+  @Override
+  public void deleteAllOutboxStaleData(LocalDateTime localDateTime) {
+    outboxJpaRepository.deleteAllOutboxStaleData(localDateTime);
+  }
 }

--- a/src/test/java/practice/hhplusecommerce/order/infrastrure/OrderMessageProducerTest.java
+++ b/src/test/java/practice/hhplusecommerce/order/infrastrure/OrderMessageProducerTest.java
@@ -1,0 +1,82 @@
+package practice.hhplusecommerce.order.infrastrure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import practice.hhplusecommerce.common.handler.TransactionalHandler;
+import practice.hhplusecommerce.order.business.command.OrderCommand;
+import practice.hhplusecommerce.order.business.command.OrderCommand.SendDataPlatform;
+import practice.hhplusecommerce.order.business.event.DataPlatformEvent;
+import practice.hhplusecommerce.order.infrastructure.kafka.OrderMessageProducer;
+import practice.hhplusecommerce.order.presentation.consumer.DataPlatformConsumer;
+import practice.hhplusecommerce.order.presentation.consumer.OutboxConsumer;
+import practice.hhplusecommerce.outbox.business.entity.Outbox;
+import practice.hhplusecommerce.outbox.business.entity.enums.OutboxState;
+import practice.hhplusecommerce.outbox.business.entity.enums.OutboxType;
+import practice.hhplusecommerce.outbox.business.repository.OutboxRepository;
+import practice.hhplusecommerce.outbox.business.service.OutboxService;
+
+@SpringBootTest
+public class OrderMessageProducerTest {
+
+  @Autowired
+  private OrderMessageProducer orderMessageProducer;
+
+  @Autowired
+  private OutboxService outboxService;
+
+  @Autowired
+  private DataPlatformConsumer dataPlatformConsumer;
+
+  @Autowired
+  private OutboxRepository outboxRepository;
+
+  @Autowired
+  private OutboxConsumer outboxConsumer;
+
+  @Autowired
+  private TransactionalHandler transactionalHandler;
+
+  @Test
+  @DisplayName("주문플랫폼 카프카 메세지 전송과 발행 정상 작동 확인")
+  public void orderPlatformPublish() throws InterruptedException {
+    //given
+    Long testId = 1L;
+    Integer testPrice = 1500;
+
+    Long outBoxId = transactionalHandler.runWithTransaction(() -> {
+      Outbox outbox = outboxService.create(OutboxType.DATA_PLATFORM);
+      DataPlatformEvent dataPlatformEvent = new DataPlatformEvent(new SendDataPlatform(testId, testId, testPrice, outbox.getId()));
+      ObjectMapper objectMapper = new ObjectMapper();
+      try {
+        outbox.saveMessage(objectMapper.writeValueAsString(dataPlatformEvent));
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+      orderMessageProducer.publish(dataPlatformEvent);
+      return outbox.getId();
+    });
+
+    //when
+    DataPlatformEvent whenDataPlatformEvent = dataPlatformConsumer.getRecords().poll(10, TimeUnit.SECONDS);
+
+    Outbox whenOutbox = outboxRepository.findById(outBoxId).get();
+
+    //then
+    assertNotNull(whenDataPlatformEvent);
+    assertEquals(whenDataPlatformEvent.getOrderId(), testId);
+    assertEquals(whenDataPlatformEvent.getOrderTotalPrice(), testPrice);
+    assertEquals(whenDataPlatformEvent.getUserId(), testId);
+    assertEquals(whenDataPlatformEvent.getUserId(), testId);
+
+    assertEquals(whenOutbox.getState(), OutboxState.PUBLISH);
+  }
+}


### PR DESCRIPTION
[Chapter 3-4] 책임 분리를 통한 애플리케이션 설계_ step_17_18


## 과제중 해당되는 내용 
1. docker 를 이용해 kafka 를 설치 및 실행하고 애플리케이션과 연결

## 커밋포인트 : [카프카 연결](https://github.com/whitewise95/hhplus-e-commerce/pull/10/commits/8df6ae2f7346c4533e94c68cc5a6c3a958758958)

###  dockerCompose로 카프카 연결 
```yml
version: '3'
services:
  zookeeper:
    image: 'confluentinc/cp-zookeeper:7.4.0'
    environment:
      ZOOKEEPER_CLIENT_PORT: 2181
      ZOOKEEPER_TICK_TIME: 2000
    ports:
      - "2181:2181"
    networks:
      - kafka-net

  kafka:
    image: 'confluentinc/cp-kafka:7.4.0'
    depends_on:
      - zookeeper
    ports:
      - "9092:9092"
    environment:
      KAFKA_BROKER_ID: 1
      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
      KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:9093,OUTSIDE://localhost:9092
      KAFKA_LISTENER_NAMES: INSIDE,OUTSIDE
      KAFKA_LISTENERS: INSIDE://0.0.0.0:9093,OUTSIDE://0.0.0.0:9092
      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'  # auto.create.topics.enable 설정

    networks:
      - kafka-net

  kafka-ui:
    image: provectuslabs/kafka-ui:latest
    depends_on:
      - kafka
    environment:
      - KAFKA_CLUSTERS_0_NAME=local
      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9093
      - KAFKA_CLUSTERS_0_ZOOKEEPER=zookeeper:2181
    ports:
      - "8081:8080"
    networks:
      - kafka-net

networks:
  kafka-net:
    driver: bridge

```


## 과제중 해당되는 내용
1. 각 프레임워크 (nest.js, spring) 에 적합하게 카프카 consumer, producer 를 연동 및 테스트
2. 기존에 애플리케이션 이벤트를 카프카 메세지 발행으로 변경
3. 카프카의 발행이 실패하는 것을 방지하기 위해 Transactional Outbox Pattern를 적용 
 
## 커밋포인트: 
1. [outbox entity 생성](https://github.com/whitewise95/hhplus-e-commerce/pull/10/commits/01fcf8575703e7ed93b65559aac251c202e0d27e)
2. [consumer, producer 생성](https://github.com/whitewise95/hhplus-e-commerce/pull/10/commits/86aad68817604c61467718ddb7eea0ff3f3d8a11)
3. [기존 주문기능과 이벤트리스너 수정 (카프카 메세지 발행으로 변경)](https://github.com/whitewise95/hhplus-e-commerce/pull/10/commits/d75f5f3279303078f898938499e9da2178e9bd34)
### 브로커로 메세지 
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/924d7ab3-4dd9-49fb-8995-5cf009270681">

## 컨슈머 
<img width="1249" alt="image" src="https://github.com/user-attachments/assets/2b9c4e91-b5f8-4361-bbe9-84e59105be18">
<img width="1254" alt="image" src="https://github.com/user-attachments/assets/2eaca60c-920f-4a3b-9918-d9a28a727cc4">



##  과제중 해당되는 내용 
1. 카프카의 발행이 실패한 케이스에 대한 재처리를 구현 ( Scheduler or BatchProcess )

## 커밋포인트
1. [재시도 스케줄러 완료](https://github.com/whitewise95/hhplus-e-commerce/pull/10/commits/843d83d4ec769737d3770d244ce57273825291bf)

```java
  @Scheduled(fixedDelay = 10000)
  @Transactional
  public void retryOutboxEvent() throws JsonProcessingException {
    LocalDateTime localDateTimeOf5MinutesAgo = LocalDateTime.now().minusMinutes(5);
    List<Outbox> outboxList = outboxRepository.findAllByFailEvent(localDateTimeOf5MinutesAgo);

    ObjectMapper objectMapper = new ObjectMapper();
    for (Outbox outbox : outboxList) {
      outbox.retry();
      DataPlatformEvent dataPlatformEvent = objectMapper.readValue(outbox.getMessage(), DataPlatformEvent.class);
      applicationEventPublisher.publishEvent(dataPlatformEvent);
    }
  }
```
